### PR TITLE
chore(ci): re-pin supply-chain-guard to v5.2.37 + enable Dependabot

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,61 +2,61 @@
   "aahp_version": "3.0",
   "project": "aahp-cron",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1782474406",
-    "timestamp": "2026-06-26T11:46:46Z",
-    "commit": "4b11c74",
-    "phase": "fix",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1782537230",
+    "timestamp": "2026-06-27T05:13:50Z",
+    "commit": "9dfd739",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:76baa5b5adbcfe38efa75ccaf8ed53ed34672a394712e7cecaa845fdba3d6e78",
-      "updated": "2026-06-26T11:45:53Z",
-      "lines": 89,
-      "summary": "(no summary available)"
+      "checksum": "sha256:8f8a8029ec0270f2bc60225b0c416864fb95589e14b9ed078278e4fcf3851d55",
+      "updated": "2026-06-27T05:13:48Z",
+      "lines": 91,
+      "summary": "﻿# aahp-cron: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:a23d91857f7cd12284fb6c21b051d607f22ffa00eb7fba17ef9140137425cb7e",
-      "updated": "2026-06-26T09:34:38Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 159,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:edd8c813a403aef252f694a28dda1893192dd7abc82dc76490d3075314a0fe1f",
-      "updated": "2026-04-30T14:10:52Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 44,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c556e022f38b6a4e89a8973d755515d692d325b962f43f0dcf49a3a8082d17f8",
-      "updated": "2026-04-30T14:10:52Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 58,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:1d955dd26c2eea2a431357f19305f26cb9c67f264b1c99f7a3daad369c2997cb",
-      "updated": "2026-04-30T14:10:52Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 73,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:8ee92e2bd7b2c32ba754e24d793c5e5754b19a159589d02ac5f72074429e18ed",
-      "updated": "2026-04-30T14:10:52Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 78,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:e40bf2e592bc5742c103cf2355fc265a45f09a2a0e2277cd1c059dc21b37b1fe",
-      "updated": "2026-04-30T14:10:52Z",
+      "updated": "2026-06-27T05:13:17Z",
       "lines": 97,
       "summary": "(no summary available)"
     }
   },
-  "quick_context": "(no summary available) (no summary available)",
+  "quick_context": "﻿# aahp-cron: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 2180,
-    "full_read": 4705
+    "manifest_plus_core": 2200,
+    "full_read": 4725
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -87,3 +87,5 @@ _AAHP verify gate: v3.0.5 synced 2026-06-20._
 > 2026-06-21 ci: add supply-chain-guard v5.2.35 Action workflow (fail-on critical).
 
 > 2026-06-21 ci(aahp): fix unquoted next_task_id + lint-handoff noreply@ PII exclusion.
+
+> 2026-06-27 ci: re-pin supply-chain-guard action to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b) and enable Dependabot github-actions weekly updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: homeofe/supply-chain-guard@89a0f2c97ff866b939b9adf8709d8b431683d937  # v5.2.35
+      - uses: homeofe/supply-chain-guard@be1d718b17cc38e4bce7fa48579b7112e557943b  # v5.2.37
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Re-pins the supply-chain-guard action from v5.2.35 (89a0f2c97ff866b939b9adf8709d8b431683d937) to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b), which includes the PR-comment crash fix (no more red Scan), and enables weekly Dependabot github-actions updates.