### PR TITLE
chore(aahp): sync canonical gate scripts and hook tooling from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,58 +3,58 @@
   "project": "aahp-cron",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1784009958",
-    "timestamp": "2026-07-14T06:19:18Z",
-    "commit": "69bfd5d",
-    "phase": "implementation",
+    "session_id": "cli-1784032317",
+    "timestamp": "2026-07-14T12:31:58Z",
+    "commit": "e7e97f9",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:072b98aadd78e5e32ff46ca812095b293336080c13f8db49fde1345d181dd4b9",
-      "updated": "2026-07-14T06:19:17Z",
-      "lines": 99,
+      "checksum": "sha256:6061b6f51772e2c7a586fffe9898f738c95bc8179823f5843780c8395b167a23",
+      "updated": "2026-07-14T12:31:38Z",
+      "lines": 101,
       "summary": "﻿# aahp-cron: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:a23d91857f7cd12284fb6c21b051d607f22ffa00eb7fba17ef9140137425cb7e",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 159,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:edd8c813a403aef252f694a28dda1893192dd7abc82dc76490d3075314a0fe1f",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 44,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c556e022f38b6a4e89a8973d755515d692d325b962f43f0dcf49a3a8082d17f8",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 58,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:1d955dd26c2eea2a431357f19305f26cb9c67f264b1c99f7a3daad369c2997cb",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 73,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:8ee92e2bd7b2c32ba754e24d793c5e5754b19a159589d02ac5f72074429e18ed",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 78,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:e40bf2e592bc5742c103cf2355fc265a45f09a2a0e2277cd1c059dc21b37b1fe",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 97,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T06:19:17Z",
+      "updated": "2026-07-14T12:29:50Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,8 +62,8 @@
   "quick_context": "﻿# aahp-cron: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 2377,
-    "full_read": 4910
+    "manifest_plus_core": 2422,
+    "full_read": 4955
   }
   ,"next_task_id": "6"
   ,"tasks": {"T-001":{"title":"[T-008] Add integration smoke test with dry-run [low]","status":"ready","priority":"low","depends_on":[],"created":"2026-06-28T10:10:28.761Z","notes":"**AAHP Task:** `T-008`  \n**Status:** ready  \n**Priority:** low  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-cron*","github_issue":26,"github_repo":"homeofe/aahp-cron"},"T-002":{"title":"[T-007] Add runtime validation for pipeline.json [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:28.761Z","notes":"**AAHP Task:** `T-007`  \n**Status:** ready  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-cron*","github_issue":25,"github_repo":"homeofe/aahp-cron"},"T-003":{"title":"[T-006] Update CI workflow to run tests and lint [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:28.762Z","notes":"**AAHP Task:** `T-006`  \n**Status:** ready  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-cron*","github_issue":24,"github_repo":"homeofe/aahp-cron"},"T-004":{"title":"[T-005] Add ESLint with TypeScript support [medium]","status":"ready","priority":"high","depends_on":[],"created":"2026-06-28T10:10:28.762Z","notes":"**AAHP Task:** `T-005`  \n**Status:** ready  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-cron*","github_issue":22,"github_repo":"homeofe/aahp-cron"},"T-005":{"title":"[T-005] Add ESLint with TypeScript support [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:14:55.116Z","notes":"**AAHP Task:** `T-005`  \n**Status:** ready  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-cron*","github_issue":23,"github_repo":"homeofe/aahp-cron"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical AAHP gate scripts from homeofe/improvements (v3.5.0 fixes: aahp-manifest.sh --phase documentation + cross_repo_ref preservation, lint-handoff.sh SC2034), AAHP_HANDOFF_FILES preserved, and refreshed the local hook tooling (scripts/hooks/, install-hooks.sh, verify-hooks.sh). Fleet re-sync.
+
 > Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
 
 ﻿# aahp-cron: Current State of the Nation

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -2,7 +2,17 @@
 # _aahp-lib.sh -Shared functions for AAHP tooling
 # Not intended to be run directly. Source this from other scripts.
 
-# Standard AAHP handoff files, in canonical order
+# Standard AAHP handoff files, in canonical order.
+#
+# PER-REPO CONFIG: this single line is the one legitimate point of variation
+# across consumer repos. It is the DEFAULT / superset used for a fresh install;
+# a consumer that tracks fewer files (e.g. no LOG-ARCHIVE.* or no
+# pii-allowlist.json) keeps its own narrower list. scripts/sync-gate-scripts.sh
+# treats exactly this line as per-repo-preserved: when it copies the canonical
+# gate scripts into a consumer it reads the consumer's existing
+# AAHP_HANDOFF_FILES=(...) line and substitutes it back in, so a sync never
+# overwrites a repo's tracked-file set. aahp-manifest.sh only indexes files that
+# actually exist, so listing a file a repo does not have is harmless.
 # shellcheck disable=SC2034
 AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
@@ -50,6 +60,9 @@ aahp_line_count() {
 aahp_auto_summary() {
     local filepath="$1"
     local summary
+    # Strip CR so a CRLF working tree (Windows) yields the same summary as an
+    # LF checkout (Linux CI). The summary is written to the non-checksummed
+    # "summary" field, so this is a cosmetic robustness fix, not a gate change.
     summary=$(head -5 "$filepath" \
         | tr -d '\r' \
         | grep -v '^#' | grep -v '^>' | grep -v '^---' | grep -v '^$' \

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --agent NAME       Agent identifier (default: "cli-tool")
 #   --session-id ID    Session identifier (default: auto-generated)
-#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle (default: "idle")
+#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle|documentation (default: "idle")
 #   --context "TEXT"    Quick context string (default: auto-generated from file summaries)
 #   --duration MIN     Session duration in minutes (default: 0)
 #   --quiet            Suppress output except errors
@@ -67,16 +67,27 @@ fi
 
 # Validate phase
 case "$PHASE" in
-    research|architecture|implementation|review|fix|idle) ;;
+    research|architecture|implementation|review|fix|idle|documentation) ;;
     *)
-        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle" >&2
+        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle, documentation" >&2
         exit 1
         ;;
 esac
 
 # ─── Detect project metadata ─────────────────────────────────
 
-PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+# Project name: PRESERVE the existing MANIFEST.json "project" value on
+# regeneration; only derive it from the directory basename on first-ever
+# generation. Without this, regenerating inside a differently-named checkout
+# (e.g. the gate-sync bot's mktemp working copy, or any tarball/CI dir) would
+# overwrite a consumer's real project name with the temp-dir basename.
+PROJECT_NAME=""
+if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
+    PROJECT_NAME="$(aahp_manifest_field "$HANDOFF_DIR/MANIFEST.json" "project")"
+fi
+if [ -z "$PROJECT_NAME" ]; then
+    PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+fi
 COMMIT=$(cd "$PROJECT_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -140,23 +151,33 @@ FULL_TOKENS=$((MANIFEST_TOKENS + TOTAL_TOKENS))
 
 TASKS_JSON=""
 NEXT_TASK_ID=""
+CROSS_REPO_REF=""
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
     if command -v node &>/dev/null; then
         EXISTING=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.tasks) process.stdout.write(JSON.stringify(m.tasks));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING" ]; then
             TASKS_JSON="$EXISTING"
         fi
         EXISTING_ID=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.next_task_id) process.stdout.write(String(m.next_task_id));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
+        fi
+        # Preserve the optional cross_repo_ref field (v3.4+), like tasks it is
+        # agent-managed and must survive regeneration.
+        EXISTING_CRR=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            if (m.cross_repo_ref) process.stdout.write(JSON.stringify(m.cross_repo_ref));
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
+        if [ -n "$EXISTING_CRR" ]; then
+            CROSS_REPO_REF="$EXISTING_CRR"
         fi
     fi
 fi
@@ -193,6 +214,9 @@ MANIFEST
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"
     fi
+    if [ -n "$CROSS_REPO_REF" ]; then
+        echo "  ,\"cross_repo_ref\": $CROSS_REPO_REF"
+    fi
 
     echo "}"
 } > "$HANDOFF_DIR/MANIFEST.json"
@@ -203,3 +227,5 @@ if [ "$QUIET" = false ]; then
     echo "MANIFEST.json generated: $FILES_FOUND files indexed, checksums current."
     echo "  Token budget: manifest=$MANIFEST_TOKENS, core=$CORE_TOKENS, full=$FULL_TOKENS"
 fi
+
+

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -41,13 +41,13 @@ HOOKS_DIR=$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)
 if [ -n "$HOOKS_DIR" ]; then
     # core.hooksPath may be relative to the repo root.
     case "$HOOKS_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
     esac
 else
     GIT_DIR=$(git -C "$TARGET" rev-parse --git-dir)
     case "$GIT_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) GIT_DIR="$TARGET/$GIT_DIR" ;;
     esac
     HOOKS_DIR="$GIT_DIR/hooks"

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -37,6 +37,18 @@ PROJECT_ROOT="."
 HANDOFF_DIR=".ai/handoff"
 VIOLATIONS=0
 
+# Resolve validate-pii-allowlist.py as a path RELATIVE to the (post-cd) cwd, so
+# native-Windows python is handed a relative path rather than an absolute MSYS
+# one. An absolute /c/Users/... path intermittently fails MSYS->Windows argv
+# conversion and surfaces as a mangled "C:\c\Users\...: can't open file"
+# artifact (a false Check-3 failure). realpath --relative-to is coreutils
+# (present on git-bash and Linux CI); where it is unavailable (e.g. BSD realpath
+# on macOS) we keep the absolute path, which opens fine there.
+PII_VALIDATOR="$SCRIPT_DIR/validate-pii-allowlist.py"
+if PII_VALIDATOR_REL="$(realpath --relative-to="$PWD" "$SCRIPT_DIR/validate-pii-allowlist.py" 2>/dev/null)"; then
+    PII_VALIDATOR="$PII_VALIDATOR_REL"
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -136,7 +148,7 @@ if [ -f "$ALLOWLIST_FILE" ]; then
         VIOLATIONS=$((VIOLATIONS + 1))
     else
         ALLOWLIST_ERR="$(mktemp)"
-        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
+        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$PII_VALIDATOR" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
             echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
         else
             ALLOWLIST_MESSAGE="$ALLOWLIST_ENTRIES"
@@ -170,13 +182,21 @@ PY
     fi
 fi
 
+# Locale-robustness (T-027): use grep -E (POSIX ERE), never grep -P (PCRE). GNU
+# grep -P aborts under a non-UTF-8 locale ("supports only unibyte and UTF-8
+# locales") and the pipeline then finds nothing, a silent FALSE PASS that made
+# the gate non-deterministic by locale. LC_ALL=C.UTF-8 pins byte-for-byte
+# identical detection across Windows git-bash, the commit hook, and Linux CI.
+# Per-MATCH filtering (T-029): grep -o extracts each address, awk excludes per
+# ADDRESS (not per line), so an excluded token (noreply / example.com /
+# placeholder) elsewhere on the same line can no longer mask a real address.
 EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null | awk -F: '{ addr=$NF; if (addr ~ /\.noreply\./ || addr ~ /^no-?reply@/ || index(addr,"example.com") || index(addr,"placeholder")) next; print }' || true)
 UNAPPROVED=""
 if [ -n "$EMAIL_MATCHES" ]; then
     while IFS= read -r match; do
         address="${match##*:}"
         allowed=0
-        while IFS=$'\t' read -r value owner expires reason; do
+        while IFS=$'\t' read -r value owner expires _; do
             [ -z "$value" ] && continue
             if [ "$address" = "$value" ]; then
                 echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# verify-hooks.sh - Read-only verification of local AAHP git-hook coverage.
+#
+# Given a target repository checkout, this classifies each REQUIRED local hook
+# (from the coverage registry in docs/hook-coverage.md) as one of:
+#   INSTALLED - hook present and byte-identical to the canonical scripts/hooks/ source
+#   DRIFTED   - hook present but its content differs from canonical
+#   EXEMPT    - hook declared exempt for this repo in the registry
+#   UNKNOWN   - required hook not installed, or the repo has no registry contract
+#
+# It MODIFIES NOTHING: it never installs, copies, backs up, or edits a hook. To
+# install or repair hooks, use scripts/install-hooks.sh instead.
+#
+# Usage:
+#   verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]
+#
+# Options:
+#   --repo owner/name   Registry key to look up. Default: derived from the
+#                       target's origin remote, falling back to the dir basename.
+#   --registry FILE     Coverage registry to read. Default: docs/hook-coverage.md
+#                       next to this script.
+#   --quiet             Suppress the banner and info lines; keep the per-hook
+#                       report and the RESULT line.
+#   --help, -h          Show this help.
+#
+# Exit codes:
+#   0 = every required hook is INSTALLED or EXEMPT
+#   1 = at least one required hook is DRIFTED or UNKNOWN (coverage gap)
+#   2 = usage error (bad option, not a git repo, registry missing)
+#
+# The drift comparison uses aahp_checksum (SHA-256, CR-stripped) so a hook
+# checksums identically on a CRLF (Windows) or LF (Linux) working tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+
+CANON_HOOKS="$SCRIPT_DIR/hooks"
+DEFAULT_REGISTRY="$SCRIPT_DIR/../docs/hook-coverage.md"
+REGISTRY_BEGIN="<!-- BEGIN hook-coverage-registry -->"
+REGISTRY_END="<!-- END hook-coverage-registry -->"
+
+TARGET=""
+REPO_SLUG=""
+REGISTRY=""
+QUIET=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)     REPO_SLUG="$2"; shift 2 ;;
+        --registry) REGISTRY="$2"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            echo "Usage: verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$TARGET" ]; then
+                TARGET="$1"; shift
+            else
+                echo "Unexpected argument: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+TARGET="${TARGET:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REGISTRY="${REGISTRY:-$DEFAULT_REGISTRY}"
+
+info() { [ "$QUIET" = true ] || echo "$@"; }
+
+# --- Validate inputs ---------------------------------------------------------
+if [ ! -f "$REGISTRY" ]; then
+    echo "Error: coverage registry not found: $REGISTRY" >&2
+    exit 2
+fi
+if ! git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: $TARGET is not a git repository." >&2
+    exit 2
+fi
+
+# --- Resolve the repo slug ---------------------------------------------------
+if [ -z "$REPO_SLUG" ]; then
+    ORIGIN_URL="$(git -C "$TARGET" remote get-url origin 2>/dev/null || true)"
+    if [ -n "$ORIGIN_URL" ]; then
+        REPO_SLUG="$(printf '%s' "$ORIGIN_URL" \
+            | sed -E 's#^[a-zA-Z]+://[^/]+/##; s#^git@[^:]+:##; s#^ssh://git@[^/]+/##; s#\.git$##')"
+    fi
+    if [ -z "$REPO_SLUG" ]; then
+        REPO_SLUG="$(basename "$(cd "$TARGET" && pwd)")"
+    fi
+fi
+
+# --- Look up the repo row in the registry ------------------------------------
+# Emit a TSV of every registry row, then select the one matching REPO_SLUG.
+ROW="$(awk -v b="$REGISTRY_BEGIN" -v e="$REGISTRY_END" '
+    index($0, b) { inblock = 1; next }
+    index($0, e) { inblock = 0 }
+    inblock && $0 ~ /^[[:space:]]*\|/ {
+        n = split($0, c, "|")
+        for (i = 1; i <= n; i++) { gsub(/^[ \t]+|[ \t]+$/, "", c[i]) }
+        repo = c[2]
+        if (repo == "" || tolower(repo) == "repo") next   # header / stray
+        if (repo ~ /^:?-+:?$/) next                        # separator row
+        printf "%s\t%s\t%s\t%s\t%s\n", repo, c[3], c[4], c[5], c[6]
+    }
+' "$REGISTRY" | awk -F'\t' -v r="$REPO_SLUG" '$1 == r { print; exit }')"
+
+info ""
+info "========================================="
+info "  AAHP hook coverage verify"
+info "========================================="
+info "  Target:   $TARGET"
+info "  Repo:     $REPO_SLUG"
+info "  Registry: $REGISTRY"
+
+if [ -z "$ROW" ]; then
+    echo "  UNKNOWN  repo '$REPO_SLUG' is not declared in the coverage registry."
+    echo "-----------------------------------------"
+    echo "  RESULT: FAIL - no coverage contract for '$REPO_SLUG' (1 unknown)."
+    exit 1
+fi
+
+IFS=$'\t' read -r R_REPO R_TYPE R_REQUIRED R_EXEMPT R_REASON <<< "$ROW"
+: "$R_REPO" "$R_REASON"   # referenced for clarity; not otherwise used
+info "  Type:     $R_TYPE"
+
+# --- Resolve the target's hooks directory (read-only) ------------------------
+HOOKS_DIR="$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$HOOKS_DIR" ]; then
+    case "$HOOKS_DIR" in
+        /*) : ;;
+        *)  HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
+    esac
+else
+    GIT_DIR="$(git -C "$TARGET" rev-parse --git-dir)"
+    case "$GIT_DIR" in
+        /*) : ;;
+        *)  GIT_DIR="$TARGET/$GIT_DIR" ;;
+    esac
+    HOOKS_DIR="$GIT_DIR/hooks"
+fi
+info "  Hooks:    $HOOKS_DIR"
+info ""
+
+# --- Build the required-hook list --------------------------------------------
+REQUIRED_LIST=()
+if [ "$R_REQUIRED" != "none" ] && [ "$R_REQUIRED" != "-" ] && [ -n "$R_REQUIRED" ]; then
+    IFS=',' read -r -a REQUIRED_LIST <<< "$R_REQUIRED"
+fi
+
+hook_is_exempt() {
+    local h="$1" x
+    case "$R_EXEMPT" in
+        ""|"-") return 1 ;;
+        "all")  return 0 ;;
+    esac
+    local ex=()
+    IFS=',' read -r -a ex <<< "$R_EXEMPT"
+    for x in "${ex[@]}"; do
+        [ "$(printf '%s' "$x" | tr -d ' ')" = "$h" ] && return 0
+    done
+    return 1
+}
+
+n_installed=0
+n_drifted=0
+n_exempt=0
+n_unknown=0
+
+if [ "${#REQUIRED_LIST[@]}" -eq 0 ]; then
+    echo "  EXEMPT     (no local hooks required for this repo)"
+    n_exempt=$((n_exempt + 1))
+else
+    for raw in "${REQUIRED_LIST[@]}"; do
+        hook="$(printf '%s' "$raw" | tr -d ' ')"
+        [ -z "$hook" ] && continue
+
+        if hook_is_exempt "$hook"; then
+            echo "  EXEMPT     $hook (declared exempt: $R_REASON)"
+            n_exempt=$((n_exempt + 1))
+            continue
+        fi
+
+        canon="$CANON_HOOKS/$hook"
+        if [ ! -f "$canon" ]; then
+            echo "  UNKNOWN    $hook (no canonical reference in scripts/hooks/)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        dest="$HOOKS_DIR/$hook"
+        if [ ! -f "$dest" ]; then
+            echo "  UNKNOWN    $hook (required hook not installed)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        if [ "$(aahp_checksum "$dest")" = "$(aahp_checksum "$canon")" ]; then
+            echo "  INSTALLED  $hook"
+            n_installed=$((n_installed + 1))
+        else
+            echo "  DRIFTED    $hook (content differs from canonical scripts/hooks/$hook)"
+            n_drifted=$((n_drifted + 1))
+        fi
+    done
+fi
+
+info "-----------------------------------------"
+FAIL=$((n_drifted + n_unknown))
+SUMMARY="installed=$n_installed drifted=$n_drifted exempt=$n_exempt unknown=$n_unknown"
+if [ "$FAIL" -gt 0 ]; then
+    echo "  RESULT: FAIL - $SUMMARY"
+    exit 1
+else
+    echo "  RESULT: PASS - $SUMMARY"
+    exit 0
+fi


### PR DESCRIPTION
Fleet re-sync of the v3.5.0 canonical AAHP gate-script fixes plus the local hook tooling (AC#6 of homeofe/improvements#8).

## What changed
- Synced the four canonical gate scripts from homeofe/improvements via scripts/sync-gate-scripts.sh:
  - scripts/_aahp-lib.sh
  - scripts/lint-handoff.sh (SC2034 fix, PII-validator relative-path + locale-robust detection)
  - scripts/aahp-manifest.sh (--phase documentation enum, cross_repo_ref / project-name preservation on regen)
  - scripts/verify-handoff.sh (unchanged, already current)
- Refreshed the local hook tooling: scripts/install-hooks.sh (updated) and scripts/verify-hooks.sh (added). scripts/hooks/pre-commit and scripts/hooks/pre-push were already byte-identical.

## Preserved
- The consumer's own AAHP_HANDOFF_FILES line was preserved verbatim (per-repo config).
- MANIFEST.json tasks / next_task_id preserved (regenerated with the repo's own aahp-manifest.sh).

## Gating
CI (aahp-verify) gates this. Local run of scripts/verify-handoff.sh --level ci passed all four layers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>